### PR TITLE
fix(version): confluence updated to `8.5.2` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Requirements
 Role Variables
 --------------
 
-- `confluence_version` The specific version of Confluence to download (default: `7.13.1`).
-- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-7.13.1.tar.gz`).
+- `confluence_version` The specific version of Confluence to download (default: `8.5.2`).
+- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-8.5.2.tar.gz`).
 - `confluence_download_url` URL to download an archive with Confluence (default: `https://www.atlassian.com/software/confluence/downloads/binary`).
 - `confluence_username` and `confluence_group` Unix username and group (default: `confluence`).
 - `confluence_root_path` Path to Confluence installation directory (default: `/opt/atlassian/confluence`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-confluence_version: '7.13.1'
+confluence_version: '8.5.2'
 confluence_archive_name: 'atlassian-confluence-{{ confluence_version }}.tar.gz'
 confluence_download_url: 'https://www.atlassian.com/software/confluence/downloads/binary'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ confluence_home_path: '/var/atlassian/application-data/confluence'
 
 # Confluence environment configuration.
 confluence_jvm_minimum_memory: '1024m'
-confluence_jvm_maximum_memory: '2048m'
+confluence_jvm_maximum_memory: '1024m'
 
 # Confluence database connection settings.
 confluence_db_configuration: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,6 +29,15 @@
         mode: 0755
       notify: 'Restart Confluence'
 
+    - name: 'Configure Confluence home'
+      ansible.builtin.template:
+        src: 'confluence-init.properties.j2'
+        dest: '{{ _confluence_application_path }}/confluence/WEB-INF/classes/confluence-init.properties'
+        owner: '{{ confluence_username }}'
+        group: '{{ confluence_group }}'
+        mode: 0644
+      notify: 'Restart Confluence'
+
     - name: 'Configure Confluence database connection'
       ansible.builtin.blockinfile:
         path: '{{ _confluence_application_path }}/confluence/WEB-INF/web.xml'

--- a/templates/confluence-init.properties.j2
+++ b/templates/confluence-init.properties.j2
@@ -1,0 +1,2 @@
+{{ ansible_managed | comment }}
+confluence.home={{ confluence_home_path }}

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -1,10 +1,7 @@
 {{ ansible_managed | comment }}
-# See the CATALINA_OPTS below for tuning the JVM arguments used to start Confluence.
-
-CONFLUENCE_HOME="{{ confluence_home_path }}"
-
-JVM_MINIMUM_MEMORY="{{ confluence_jvm_minimum_memory }}"
-JVM_MAXIMUM_MEMORY="{{ confluence_jvm_maximum_memory }}"
+#-----------------------------------------------------------------------------------
+# See the CATALINA_OPTS below for tuning the JVM arguments used to start Confluence
+#-----------------------------------------------------------------------------------
 
 echo "If you encounter issues starting up Confluence, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
 
@@ -65,27 +62,71 @@ export CONFLUENCE_CONTEXT_PATH
 $JRE_HOME/bin/java -jar $CATALINA_HOME/bin/synchrony-proxy-watchdog.jar $CATALINA_HOME
 echo "---------------------------------------------------------------------------"
 
-# Set the JVM arguments used to start Confluence.
-# For a description of the vm options of jdk 8, see:
-# http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
-# For a description of the vm options of jdk 11, see:
+#-----------------------------------------------------------------------------------
+# This section contains commonly modified Java options and system properties
+# When upgrading Confluence, copy this section to reapply your customizations
+# Always the review the new file for any changes to the default values
+
+# To learn more about Java 11 options see:
 # https://docs.oracle.com/en/java/javase/11/tools/java.html
+#-----------------------------------------------------------------------------------
+
+# Set the Java heap size
+CATALINA_OPTS="-Xms{{ confluence_jvm_minimum_memory }} -Xmx{{ confluence_jvm_minimum_memory }} ${CATALINA_OPTS}"
+
+# Default values for small to medium size instances
+CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m ${CATALINA_OPTS}"
+
+# Add various JPMS arguments to allow Confluence to work on Java 17
+CATALINA_OPTS="@$CATALINA_HOME/confluence/WEB-INF/jpms-args.txt ${CATALINA_OPTS}"
+
+# Default garbage collector and its settings
+if [ -z "${CONFLUENCE_GC_OPTS}" ]; then
+  CONFLUENCE_GC_OPTS="-XX:G1ReservePercent=20 -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent"
+fi
+
+# Default garbage collector log
+if [ -z "${CONFLUENCE_GC_LOG}" ]; then
+  CONFLUENCE_GC_LOG="-Xlog:gc*:file=$LOGBASEABS/logs/gc-%t.log:tags,time,uptime,level:filecount=5,filesize=2M"
+fi
+
+# Recommended values for medium to large, and enterprise size instances
+# For -XX:ReservedCodeCacheSize - comment out the default values in the block above, then uncomment the values below
+#CATALINA_OPTS="-XX:ReservedCodeCacheSize=384m ${CATALINA_OPTS}"
+# To learn more about the impact of disabling the upgrade recovery file see:
+# https://confluence.atlassian.com/x/ShtwPg
+#CATALINA_OPTS="-Dconfluence.upgrade.recovery.file.enabled=false ${CATALINA_OPTS}"
+# For -Xlog:gc - uncomment the default values in the block below, then comment out the values in the last block of this file
+#CATALINA_OPTS="-Xlog:gc*=debug:file=$LOGBASEABS/logs/gc-%t.log:tags,time,uptime,level:filecount=5,filesize=2M ${CATALINA_OPTS}"
+
+# Additional Confluence system properties
+# For a list of properties recognized by Confluence see:
+# https://confluence.atlassian.com/display/DOC/Recognized+System+Properties
+# We recommend you include a support ticket ID and/or note to help track the reason for change
+# For example:
+# CSP-123456 - Added example JVM option to help explain this section
+#CATALINA_OPTS="-Dexample.property=true ${CATALINA_OPTS}"
+
+# Uncomment this line to disable email notifications
+#CATALINA_OPTS="-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true ${CATALINA_OPTS}"
+
+#-----------------------------------------------------------------------------------
+# End of commonly modified Java options. You should not need to change the options
+# below unless recommended by Atlassian Support
+#-----------------------------------------------------------------------------------
+
 CATALINA_OPTS="-XX:+IgnoreUnrecognizedVMOptions ${CATALINA_OPTS}"
-CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
-CATALINA_OPTS="-Xlog:gc+age=debug:file=$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log::filecount=5,filesize=2M ${CATALINA_OPTS}"
-CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
-CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
+CATALINA_OPTS="${CONFLUENCE_GC_OPTS} ${CATALINA_OPTS}"
+CATALINA_OPTS="${CONFLUENCE_GC_LOG} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
 CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
-CATALINA_OPTS="-Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 ${CATALINA_OPTS}"
-CATALINA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:+UseG1GC ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dsynchrony.enable.xhr.fallback=true ${CATALINA_OPTS}"
-CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
-CATALINA_OPTS="-Djava.locale.providers=JRE,SPI,CLDR ${CATALINA_OPTS}"
-CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
-CATALINA_OPTS="-Dconfluence.home=${CONFLUENCE_HOME} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
-CATALINA_OPTS="-Djdk.tls.server.protocols=TLSv1.1,TLSv1.2 -Djdk.tls.client.protocols=TLSv1.1,TLSv1.2 ${CATALINA_OPTS}"
-CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
+CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
 
 export CATALINA_OPTS
+
+#-----------------------------------------------------------------------------------
+# End configuration options
+#-----------------------------------------------------------------------------------


### PR DESCRIPTION
Atlassian released a new LTS version of [Confluence](https://confluence.atlassian.com/display/DOC/Confluence+8.5+Release+Notes) - **8.5.2**!

This automated PR updates code to bring new version into repository.