### PR TITLE
fix(version): confluence updated to `8.5.4` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Requirements
 Role Variables
 --------------
 
-- `confluence_version` The specific version of Confluence to download (default: `8.5.3`).
-- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-8.5.3.tar.gz`).
+- `confluence_version` The specific version of Confluence to download (default: `8.5.4`).
+- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-8.5.4.tar.gz`).
 - `confluence_download_url` URL to download an archive with Confluence (default: `https://www.atlassian.com/software/confluence/downloads/binary`).
 - `confluence_username` and `confluence_group` Unix username and group (default: `confluence`).
 - `confluence_root_path` Path to Confluence installation directory (default: `/opt/atlassian/confluence`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-confluence_version: '8.5.3'
+confluence_version: '8.5.4'
 confluence_archive_name: 'atlassian-confluence-{{ confluence_version }}.tar.gz'
 confluence_download_url: 'https://www.atlassian.com/software/confluence/downloads/binary'
 


### PR DESCRIPTION
Atlassian released a new LTS version of [Confluence](https://confluence.atlassian.com/display/DOC/Confluence+8.5+Release+Notes) - **8.5.4**!

This automated PR updates code to bring new version into repository.