### PR TITLE
fix(version): confluence updated to `8.5.12` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Requirements
 Role Variables
 --------------
 
-- `confluence_version` The version of Confluence to download (default: `8.5.11`).
-- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-8.5.11.tar.gz`).
+- `confluence_version` The version of Confluence to download (default: `8.5.12`).
+- `confluence_archive_name` Confluence archive name (default: `atlassian-confluence-8.5.12.tar.gz`).
 - `confluence_download_url` URL to download the Confluence archive (default: `https://www.atlassian.com/software/confluence/downloads/binary`).
 - `confluence_download_path` Local path to download and extract the archive (default: `/tmp`).
 - `confluence_user` and `confluence_group` System user and group that will be created (default: `confluence`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-confluence_version: '8.5.11'
+confluence_version: '8.5.12'
 confluence_archive_name: 'atlassian-confluence-{{ confluence_version }}.tar.gz'
 confluence_download_url: 'https://www.atlassian.com/software/confluence/downloads/binary'
 confluence_download_path: '/tmp'


### PR DESCRIPTION
Atlassian released a new LTS version of [Confluence](https://confluence.atlassian.com/display/DOC/Confluence+8.5+Release+Notes) - **8.5.12**!

This automated PR updates code to bring new version into repository.