### PR TITLE
fix(version): confluence updated to `9.2.0` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-confluence_version: '8.5.18'
+confluence_version: '9.2.0'
 confluence_archive_name: 'atlassian-confluence-{{ confluence_version }}.tar.gz'
 confluence_download_url: 'https://www.atlassian.com/software/confluence/downloads/binary'
 confluence_checksum_url: '{{ confluence_download_url }}/{{ confluence_archive_name }}.sha256'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       confluence_version:
         type: 'str'
         description: 'The version of Confluence to download.'
-        default: '8.5.18'
+        default: '9.2.0'
       confluence_archive_name:
         type: 'str'
         description: 'Confluence archive name.'

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -38,6 +38,7 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
+
 # IMPORTANT NOTE: Only set JAVA_HOME or JRE_HOME above this line
 # Get standard Java environment variables
 if $os400; then
@@ -46,6 +47,9 @@ if $os400; then
   # 2. owned by the PRIMARY group of the user
   # this will not work if the user belongs in secondary groups
   . "$CATALINA_HOME"/bin/setjre.sh
+{% if confluence_version is version('9.1.0', '>=') %}
+  . "$CATALINA_HOME"/bin/check-java.sh
+{% endif %}
 else
   if [ -r "$CATALINA_HOME"/bin/setjre.sh ]; then
     . "$CATALINA_HOME"/bin/setjre.sh
@@ -54,6 +58,16 @@ else
     echo "This file is needed to run this program"
     exit 1
   fi
+{% if confluence_version is version('9.1.0', '>=') %}
+  # Check Java Version
+  if [ -r "$CATALINA_HOME"/bin/check-java.sh ]; then
+    . "$CATALINA_HOME"/bin/check-java.sh
+  else
+    echo "Cannot find $CATALINA_HOME/bin/check-java.sh"
+    echo "This file is needed to run this program"
+    exit 1
+  fi
+{% endif %}
 fi
 
 echo "---------------------------------------------------------------------------"


### PR DESCRIPTION
Atlassian released a new LTS version of [Confluence](https://confluence.atlassian.com/display/DOC/Confluence+9.2+Release+Notes) - **9.2.0**!

This automated PR updates code to bring new version into repository.