### PR TITLE
fix(version): confluence updated to `9.2.19` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-confluence_version: '9.2.17'
+confluence_version: '9.2.19'
 confluence_archive_name: 'atlassian-confluence-{{ confluence_version }}.tar.gz'
 confluence_download_url: 'https://www.atlassian.com/software/confluence/downloads/binary'
 confluence_checksum_url: '{{ confluence_download_url }}/{{ confluence_archive_name }}.sha256'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       confluence_version:
         type: 'str'
         description: 'The version of Confluence to download.'
-        default: '9.2.17'
+        default: '9.2.19'
       confluence_archive_name:
         type: 'str'
         description: 'Confluence archive name.'


### PR DESCRIPTION
Atlassian released a new LTS version of [Confluence](https://confluence.atlassian.com/display/DOC/Confluence+9.2+Release+Notes) - **9.2.19**!

This automated PR updates code to bring new version into repository.